### PR TITLE
feat: adding support for github artifact repository

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,3 +28,9 @@ jobs:
           java-distribution: temurin
           java-version: "17"
           repository: bcgov/nr-forest-client          
+          sonar_args: >
+            -Dsonar.exclusions=**/coverage/**
+            -Dsonar.organization=bcgov-nr
+            -Dsonar.projectKey=bcgov-nr_action-test-and-analyse-java
+          sonar_project_token: ${{ secrets.SONAR_TOKEN }}
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: ./
         with:
           commands: |
-            mvn test
+            mvn -B verify -P all-tests checkstyle:checkstyle -Dcheckstyle.skip=false --file pom.xml
           dir: backend
           java-distribution: temurin
           java-version: "17"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: ./
         with:
           commands: |
-            ./mvnw test
+            mvn test
           dir: backend
           java-distribution: temurin
           java-version: "17"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,6 @@ jobs:
           java-version: "17"
           repository: bcgov/nr-forest-client
           sonar_args: >
-            -Dsonar.exclusions=**/coverage/**
-            -Dsonar.organization=bcgov-nr
-            -Dsonar.projectKey=bcgov-nr_action-test-and-analyse-java
+            -Dsonar.organization=bcgov-sonarcloud
+            -Dsonar.projectKey=forest-client-backend
           sonar_project_token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,6 +31,6 @@ jobs:
           sonar_args: >
             -Dsonar.exclusions=**/coverage/**
             -Dsonar.organization=bcgov-nr
-            -Dsonar.projectKey=bcgov-nr_action-test-and-analyse-java
+            -Dsonar.projectKey=action-test-and-analyse-java
           sonar_project_token: ${{ secrets.SONAR_TOKEN }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,5 +32,5 @@ jobs:
             -Dsonar.exclusions=**/coverage/**
             -Dsonar.organization=bcgov-nr
             -Dsonar.projectKey=bcgov-nr_action-test-and-analyse-java
-            -Dsonar.branch.name=${{ github.ref_name }}
+            -Dsonar.branch.name=main
           sonar_project_token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,10 +27,4 @@ jobs:
           dir: backend
           java-distribution: temurin
           java-version: "17"
-          repository: bcgov/nr-forest-client
-          sonar_args: >
-            -Dsonar.exclusions=**/coverage/**
-            -Dsonar.organization=bcgov-nr
-            -Dsonar.projectKey=bcgov-nr_action-test-and-analyse-java
-            -Dsonar.branch.name=main
-          sonar_project_token: ""
+          repository: bcgov/nr-forest-client          

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,6 +29,8 @@ jobs:
           java-version: "17"
           repository: bcgov/nr-forest-client
           sonar_args: >
-            -Dsonar.organization=bcgov-sonarcloud
-            -Dsonar.projectKey=forest-client-backend
+            -Dsonar.exclusions=**/coverage/**
+            -Dsonar.organization=bcgov-nr
+            -Dsonar.projectKey=bcgov-nr_action-test-and-analyse-java
+            -Dsonar.branch.name=${{ github.ref_name }}
           sonar_project_token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,4 +33,4 @@ jobs:
             -Dsonar.organization=bcgov-nr
             -Dsonar.projectKey=bcgov-nr_action-test-and-analyse-java
             -Dsonar.branch.name=main
-          sonar_project_token: ${{ secrets.SONAR_TOKEN }}
+          sonar_project_token: ""

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 [Issues]: https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue
 [Pull Requests]: https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/working-with-your-remote-repository-on-github-or-github-enterprise/creating-an-issue-or-pull-request
 
-# Unit Test (Java), Coverage and Analysis with SonarCloud
+# Test (Java), Coverage and Analysis with SonarCloud
 
-This action runs unit tests and optionally runs analysis, including coverage, using [SonarCloud](https://sonarcloud.io).  SonarCloud can be configured to comment on pull requests or stop failing workflows.
+This action runs tests and optionally runs analysis, including coverage, using [SonarCloud](https://sonarcloud.io).  SonarCloud can be configured to comment on pull requests or stop failing workflows. Also this action automatically configures the github package server in a settings file to import dependencies from it during execution.
 
 This Action supports Java.  Another for [JavaScript/TypeScript](https://github.com/bcgov-nr/action-test-and-analyse) is available.
 

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         fi
 
         if [ ${{ inputs.java-cache }} == "maven" ]; then
-          sonarCmd="mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -s $GITHUB_WORKSPACE/settings.xml"
+          sonarCmd="mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar"
         elif [ ${{ inputs.java-cache }} == "gradle" ]; then
           sonarCmd="./gradlew build sonarqube --info"
         else
@@ -79,15 +79,13 @@ runs:
         distribution: ${{ inputs.java-distribution }}
         java-version: ${{ inputs.java-version }}
         server-id: 'github'
-        settings-path: ${{ github.workspace }}
 
     # Run tests, hopefully generating coverage for SonarCloud
     - shell: bash
       run: |
         # Run tests
         cd ${{ inputs.dir }}
-        mkdir -p /home/runner/.m2/
-        cp $GITHUB_WORKSPACE/settings.xml /home/runner/.m2/
+        cat /home/runner/.m2/settings.xml                
         ${{ inputs.commands }}
 
     ### Optional SonarCloud

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,7 @@ runs:
         # Run tests
         cd ${{ inputs.dir }}
         mvn -X clean | grep "settings"
+        cat /home/runner/.m2/settings.xml
 
     ### Optional SonarCloud
 

--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,6 @@ runs:
       run: |
         # Run tests
         cd ${{ inputs.dir }}
-        cat /home/runner/.m2/settings.xml                
         ${{ inputs.commands }}
 
     ### Optional SonarCloud

--- a/action.yml
+++ b/action.yml
@@ -98,9 +98,8 @@ runs:
       run: |
         # Run SonarCloud for ${{ inputs.java-cache }}
         cd ${{ inputs.dir }}
-        ${{ steps.inputs.outputs.sonarCmd }} \
-          -Dsonar.host.url=https://sonarcloud.io ${{ inputs.sonar_args }} \
-          -s $GITHUB_WORKSPACE/settings.xml
+        ${{ steps.inputs.outputs.sonarCmd }} -s $GITHUB_WORKSPACE/settings.xml \
+          -Dsonar.host.url=https://sonarcloud.io ${{ inputs.sonar_args }}
 
     ### Cleanup
 

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         fi
 
         if [ ${{ inputs.java-cache }} == "maven" ]; then
-          sonarCmd="mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar"
+          sonarCmd="mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -s $GITHUB_WORKSPACE/settings.xml"
         elif [ ${{ inputs.java-cache }} == "gradle" ]; then
           sonarCmd="./gradlew build sonarqube --info"
         else
@@ -88,8 +88,7 @@ runs:
         cd ${{ inputs.dir }}
         mkdir -p /home/runner/.m2/
         cp $GITHUB_WORKSPACE/settings.xml /home/runner/.m2/
-        mvn -X clean | grep "settings"
-        cat /home/runner/.m2/settings.xml
+        ${{ inputs.commands }}
 
     ### Optional SonarCloud
 
@@ -101,7 +100,8 @@ runs:
       run: |
         # Run SonarCloud for ${{ inputs.java-cache }}
         cd ${{ inputs.dir }}
-        M2_HOME=$GITHUB_WORKSPACE mvn -X clean | grep "settings"
+        ${{ steps.inputs.outputs.sonarCmd }} \
+          -Dsonar.host.url=https://sonarcloud.io ${{ inputs.sonar_args }}
 
     ### Cleanup
 

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
       run: |
         # Run tests
         cd ${{ inputs.dir }}
-        ${{ inputs.commands }} -s $GITHUB_WORKSPACE/settings.xml
+        mvn -X clean | grep "settings"
 
     ### Optional SonarCloud
 
@@ -98,8 +98,7 @@ runs:
       run: |
         # Run SonarCloud for ${{ inputs.java-cache }}
         cd ${{ inputs.dir }}
-        ${{ steps.inputs.outputs.sonarCmd }} -s $GITHUB_WORKSPACE/settings.xml \
-          -Dsonar.host.url=https://sonarcloud.io ${{ inputs.sonar_args }}
+        M2_HOME=$GITHUB_WORKSPACE mvn -X clean | grep "settings"
 
     ### Cleanup
 

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,8 @@ runs:
         cache: ${{ inputs.java-cache }}
         distribution: ${{ inputs.java-distribution }}
         java-version: ${{ inputs.java-version }}
+        server-id: 'github'
+        settings-path: ${{ github.workspace }}
 
     # Run tests, hopefully generating coverage for SonarCloud
     - shell: bash

--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,8 @@ runs:
       run: |
         # Run tests
         cd ${{ inputs.dir }}
+        mkdir -p /home/runner/.m2/
+        cp $GITHUB_WORKSPACE/settings.xml /home/runner/.m2/
         mvn -X clean | grep "settings"
         cat /home/runner/.m2/settings.xml
 

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
       run: |
         # Run tests
         cd ${{ inputs.dir }}
-        ${{ inputs.commands }}
+        ${{ inputs.commands }} -s $GITHUB_WORKSPACE/settings.xml
 
     ### Optional SonarCloud
 
@@ -99,7 +99,8 @@ runs:
         # Run SonarCloud for ${{ inputs.java-cache }}
         cd ${{ inputs.dir }}
         ${{ steps.inputs.outputs.sonarCmd }} \
-          -Dsonar.host.url=https://sonarcloud.io ${{ inputs.sonar_args }}
+          -Dsonar.host.url=https://sonarcloud.io ${{ inputs.sonar_args }} \
+          -s $GITHUB_WORKSPACE/settings.xml
 
     ### Cleanup
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+      "config:base"
+    ]
+  }


### PR DESCRIPTION
Proper configuration that allows java code to use the GitHub artifact repository for maven/gradle.

This configuration will automatically configure the settings.xml file for server access.

To consume it, users should pass `-s $GITHUB_WORKSPACE/settings.xml` as part of the maven command line. Still investigating for gradle though